### PR TITLE
Path port

### DIFF
--- a/demos/dfns/README.md
+++ b/demos/dfns/README.md
@@ -1,0 +1,14 @@
+<!-- TITLE/ -->
+
+## General Utility Functions
+
+<!-- /TITLE -->
+
+
+---
+
+This directory contains some of the curated utility functions from http://dfns.dyalog.com/ which have been translated to April APL.
+
+### Getting started
+
+`cd` into a subdirectory and evaluate the expressions in `usage.lisp`

--- a/demos/dfns/path/path.apl
+++ b/demos/dfns/path/path.apl
@@ -1,0 +1,17 @@
+⍝  a port of http://dfns.dyalog.com/c_path.htm into April APL
+
+
+path←{                                  ⍝ Shortest path from/to ⍵ in graph ⍺.
+      graph (fm to)←⍺ ⍵                 ⍝ graph and entry/exit vertex vectors
+      fm{                               ⍝ fm is the starting-from vertex
+        $[⍺≡⍬;⍬;                        ⍝ no vertices left: no path
+        $[∨/to∊⍺;⍬(⊃∘⍵) {               ⍝ found target: path from tree:
+                         $[⍵<0;⍺;       ⍝ root: finished
+                         (⍵,⍺) ∇ ⍺⍺ ⍵]  ⍝ accumulated path to next vertex
+                        } 1↑⍺∩to;       ⍝ found vertex ⍺
+        next←graph[⍺]∩¨⊂⍸⍵=¯2           ⍝ next vertices to visit
+        back←⊃,/⍺+0×next                ⍝ back links
+        wave←⊃,/next                    ⍝ vertex wave front
+        (∪wave) ∇ back@wave⊢⍵]]         ⍝ advanced wave front
+      }¯2+(⍳⍴⍺)∊fm                      ⍝ null spanning tree
+}

--- a/demos/dfns/path/usage.lisp
+++ b/demos/dfns/path/usage.lisp
@@ -1,0 +1,25 @@
+(ql:quickload "april")
+(in-package "april")
+(april-load #p"path.apl")
+
+
+;; http://dfns.dyalog.com/s_path.htm
+
+; directed graph.
+(april "g← (2 3) (3) (2 4) (1 5) (3)")
+
+; single vertex→vertex path.
+(april "g path 2 1 ")
+; #(2 3 4 1)
+
+; multiple vertex→vertex path.
+(april "g path (1 2)(4 5)")
+; #(2 3 4)
+
+; each to every single vertex.
+(april "g∘path¨⍳5 5")
+; #2A((#(1) #(1 2) #(1 3) #(1 3 4) #(1 3 4 5))
+;     (#(2 3 4 1) #(2) #(2 3) #(2 3 4) #(2 3 4 5))
+;     (#(3 4 1) #(3 2) #(3) #(3 4) #(3 4 5))
+;     (#(4 1) #(4 1 2) #(4 5 3) #(4) #(4 5))
+;     (#(5 3 4 1) #(5 3 2) #(5 3) #(5 3 4) #(5)))

--- a/demos/dfns/path/usage.lisp
+++ b/demos/dfns/path/usage.lisp
@@ -1,5 +1,5 @@
 (ql:quickload "april")
-(in-package "april")
+(in-package :april)
 (april-load #p"path.apl")
 
 


### PR DESCRIPTION
ported dyalog's path graph function.

this works at commit c80d7cf12577d7a28656dccd1c9bc9d9ab28031a but not HEAD.