### PR TITLE
APLESQUE:IS-INTEGER-ARRAY now takes into account that the array eleme…

### DIFF
--- a/aplesque/aplesque.lisp
+++ b/aplesque/aplesque.lisp
@@ -351,9 +351,10 @@
     (or (eql 'bit type)
         (eql 'fixnum type)
         (eql 'bignum type)
-        (eql 'integer (first type))
-        (eql 'unsigned-byte (first type))
-        (eql 'signed-byte (first type)))))
+        (and (listp type)
+             (or (eql 'integer (first type))
+                 (eql 'unsigned-byte (first type))
+                 (eql 'signed-byte (first type)))))))
 
 (defun across (input function &key elements indices reverse-axes count ranges
                                 foreach finally (depth 0) (dimensions (dims input)))


### PR DESCRIPTION
aplesque:is-integer-array fails when the array element type is double-float, this was discovered when trying to create an array of random floats.

```
* (ql:quickload "april")
To load "april":
  Load 1 ASDF system:
    april
; Loading "april"
.....
Specified idiom ｢APRIL｣ with 97 lexical functions, 16 lexical operators, 24 utility functions and 1033 unit tests.


("april")
* (april:april "?2 2⍴1.0")

debugger invoked on a TYPE-ERROR @5376731C in thread
#<THREAD "main thread" RUNNING {1004E50073}>:
  The value
    DOUBLE-FLOAT
  is not of type
    LIST

Type HELP for debugger help, or (SB-EXT:EXIT) to exit from SBCL.

restarts (invokable by number or by possibly-abbreviated name):
  0: [ABORT] Exit debugger, returning to top level.

(APLESQUE:IS-INTEGER-ARRAY #2A((1.0d0 1.0d0) (1.0d0 1.0d0)))
   source: (FIRST TYPE)
0]
```