### PR TITLE
Fix a missing gensym unquote in for-printed.

### DIFF
--- a/vex/vex.lisp
+++ b/vex/vex.lisp
@@ -178,7 +178,7 @@
                                                             ,(concatenate 'string '(#\Newline)
                                                                           "    "))))
                                        (when (or (zerop (length ,output))
-                                                 (not (char= #\Newline (aref output (1- (length ,output))))))
+                                                 (not (char= #\Newline (aref ,output (1- (length ,output))))))
                                          (princ #\Newline))))))))))))))
   
 (defun process-arbitrary-tests-for (symbol test-set &key (mode :test))


### PR DESCRIPTION
I noticed the demo was failing, and this time was able to track down the off-by-one error myself (or at least see the missing comma)! The bug appears to have been introduced in 615aa21081fe155f56aeba7140c876d176c80a09; I haven't scanned that commit for possible further typos. Yet.