### PR TITLE
Fix maxpc-apache tests

### DIFF
--- a/maxpc-apache/interface.lisp
+++ b/maxpc-apache/interface.lisp
@@ -87,7 +87,7 @@
     (error "GET-INPUT-POSITION may only be called inside ?FAIL, %HANDLER-CASE
 and %RESTART-CASE."))
   (let ((position (input-position *input-fail*)))
-    (if (eq (input-element-type *input-fail*) 'character)
+    (if (subtypep (input-element-type *input-fail*) 'character)
 	(multiple-value-bind (line character)
 	    (parse-line-position *input-start* position)
 	  (values position line character))

--- a/maxpc-apache/maxpc-apache-test.asd
+++ b/maxpc-apache/maxpc-apache-test.asd
@@ -2,7 +2,7 @@
 
 #+asdf3 (in-package :asdf-user)
 
-(defsystem maxpc-apache
+(defsystem maxpc-apache-test
   :description
   "Test and benchmark suite for MaxPC."
   :author "Max Rottenkolber <max@mr.gy>"


### PR DESCRIPTION
On SBCL, input-element-type was BASE-CHAR.

Found when parsing all .asd's in Quicklisp.